### PR TITLE
fix bug with keylist

### DIFF
--- a/poly-noweb.el
+++ b/poly-noweb.el
@@ -114,7 +114,7 @@ not a function, use `poly-fallback-mode'."
                poly-noweb-pdflatex-exporter
                poly-noweb-lualatex-exporter
                poly-noweb-xelatex-exporter)
-  :keylist '(("<" . poly-noweb-electric-<)))
+  :keylist '("<" poly-noweb-electric-<))
 
 (defun poly-noweb-electric-< (arg)
   "Auto insert noweb chunk if at bol followed by white space.


### PR DESCRIPTION
Loading this module causes this error on startup:

```poly-R.el:57:11: Error: Uneven number of key/definition pairs```

The issue seems to be a compatibility with newer versions of polymode. The ~2026 version seems to appears to now uses define-keymap internally and expects a flat list of key/function pairs rather than an alist.

This is a 1-line (2 character!) patch but is essential to even use this.

The old alist format `'(("key" . func))` causes an "Uneven number of key/definition pairs" error at load time.