### PR TITLE
fix: use flat keylist pairs for Emacs 30 define-keymap compatibility

### DIFF
--- a/poly-noweb.el
+++ b/poly-noweb.el
@@ -114,7 +114,7 @@ not a function, use `poly-fallback-mode'."
                poly-noweb-pdflatex-exporter
                poly-noweb-lualatex-exporter
                poly-noweb-xelatex-exporter)
-  :keylist '(("<" . poly-noweb-electric-<)))
+  :keylist '("<" poly-noweb-electric-<))
 
 (defun poly-noweb-electric-< (arg)
   "Auto insert noweb chunk if at bol followed by white space.


### PR DESCRIPTION
Emacs 30's define-keymap no longer accepts cons cell pairs like ("<" . func). Changed to flat key/value pairs: "<" func.